### PR TITLE
Add support for tables with wildcards in the end

### DIFF
--- a/drush/tests/DatabaseSanitizeTest.php
+++ b/drush/tests/DatabaseSanitizeTest.php
@@ -102,13 +102,15 @@ class DatabaseSanitizeCase extends CommandUnishTestCase {
   public function testDatabaseSanitizeCommands() {
     // @see assets/database.sanitize.merge.yml
     $this->assertContains('users', $this->dbTables);
+    $this->drush('sqlq', ['show tables like "user__field_%";'], $this->siteOptions);
+    $wildcard_tables = $this->getOutputAsList();
 
     // Test db-sanitize-analyze command.
     $analyze_options = $this->siteOptions + [
       'file' => $this->mergeYmlFile,
     ];
 
-    $dumped_tables_expected = count($this->dbTables) - 1;
+    $dumped_tables_expected = count($this->dbTables) - (1 + count($wildcard_tables));
     $this->drush('db-sanitize-analyze', [], $analyze_options);
     $eds_analyze_output = $this->getErrorOutput();
     $this->assertContains(sprintf('There are %s tables not defined on sanitize YML files', $dumped_tables_expected), $eds_analyze_output);

--- a/drush/tests/DatabaseSanitizeTest.php
+++ b/drush/tests/DatabaseSanitizeTest.php
@@ -84,7 +84,7 @@ class DatabaseSanitizeCase extends CommandUnishTestCase {
     \symlink($target, $this->webRoot . '/modules/database_sanitize');
 
     $this->drush('cache-clear', ['drush'], $this->siteOptions);
-    $this->drush('pm-enable', ['database_sanitize'], $this->siteOptions);
+    $this->drush('pm-enable', ['database_sanitize', 'node'], $this->siteOptions);
 
     // Get tables defined in the database.
     $this->drush('sqlq', ['show tables;'], $this->siteOptions);
@@ -102,7 +102,7 @@ class DatabaseSanitizeCase extends CommandUnishTestCase {
   public function testDatabaseSanitizeCommands() {
     // @see assets/database.sanitize.merge.yml
     $this->assertContains('users', $this->dbTables);
-    $this->drush('sqlq', ['show tables like "user__field_%";'], $this->siteOptions);
+    $this->drush('sqlq', ['show tables like "node_revision%";'], $this->siteOptions);
     $wildcard_tables = $this->getOutputAsList();
 
     // Test db-sanitize-analyze command.

--- a/drush/tests/assets/database.sanitize.merge.yml
+++ b/drush/tests/assets/database.sanitize.merge.yml
@@ -3,4 +3,4 @@ sanitize:
         users:
             description: 'This is a test'
             query: 'TRUNCATE users'
-        user__field_*: false
+        node_revision*: false

--- a/drush/tests/assets/database.sanitize.merge.yml
+++ b/drush/tests/assets/database.sanitize.merge.yml
@@ -3,3 +3,4 @@ sanitize:
         users:
             description: 'This is a test'
             query: 'TRUNCATE users'
+        user__field_*: false

--- a/src/DatabaseSanitize.php
+++ b/src/DatabaseSanitize.php
@@ -232,11 +232,14 @@ class DatabaseSanitize {
         }
 
         // Support for tables with wildcards in the end.
-        if (substr($yml_table, -1) == '*') {
-          $yml_table_pattern = substr($yml_table, 0, -1);
-          if (substr($table_name, 0, strlen($yml_table_pattern)) === $yml_table_pattern) {
-            continue;
+        if (substr($table_name, -1) == '*') {
+          $table_pattern = substr($table_name, 0, -1);
+          foreach ($db_tables as $db_table) {
+            if (substr($db_table, 0, strlen($table_pattern)) === $table_pattern) {
+              array_push($yml_tables, $db_table);
+            }
           }
+          continue;
         }
 
         array_push($yml_tables, $table_name);

--- a/src/DatabaseSanitize.php
+++ b/src/DatabaseSanitize.php
@@ -231,6 +231,14 @@ class DatabaseSanitize {
           continue;
         }
 
+        // Support for tables with wildcards in the end.
+        if (substr($yml_table, -1) == '*') {
+          $yml_table_pattern = substr($yml_table, 0, -1);
+          if (substr($table_name, 0, strlen($yml_table_pattern)) === $yml_table_pattern) {
+            continue;
+          }
+        }
+
         array_push($yml_tables, $table_name);
       }
     }


### PR DESCRIPTION
### Description
We need to add support for tables being defined with wildcards, for example matching `field_deleted_revision_*` to `field_deleted_revision_3b066e8ccb`

