### PR TITLE
#3060557 Use database schema instead of a database query

### DIFF
--- a/database_sanitize.install
+++ b/database_sanitize.install
@@ -53,7 +53,7 @@ function database_sanitize_requirements($phase) {
       return $requirements;
     }
 
-    $db_tables = \Drupal::database()->query('show tables')->fetchCol();
+    $db_tables = \Drupal::service('database')->schema()->findTables('%');
 
     $yml_tables = [];
     foreach ($parsed_file['sanitize'] as $machine_name => $tables) {

--- a/database_sanitize.services.yml
+++ b/database_sanitize.services.yml
@@ -2,4 +2,4 @@ services:
   database_sanitize:
     class: Drupal\database_sanitize\DatabaseSanitize
     public: true
-    arguments: ['@logger.factory']
+    arguments: ['@logger.factory', '@database']


### PR DESCRIPTION
### Issue links
https://www.drupal.org/project/database_sanitize/issues/3060557

### Description
We're currently using `$db_tables = \Drupal::database()->query('show tables')->fetchCol();` which isn't compatible with all drivers.

**Proposed resolution**
Use `$db_tables = \Drupal::service('database')->schema()->findTables('%');` instead, which is compatible with all drivers.
