### PR TITLE
Document using wildcards for table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ sanitize:
         DBTABLENAME3:
             description: 'query description'
             query: 'DB QUERY 3'
+        DBTABLENAME4: false
+        DBTABLENAMEPREFIX*: false
 ```
+
+Using a wildcard `*` for table names is supported. For example, setting `node_revision*` will apply to all tables names starting with `node_revision`.
 
 ### Commands usage
 To find out how many tables needs to be defined in `database.sanitize.yml` files:


### PR DESCRIPTION
### Issue links
None

### Description
We have an undocumented feature of the yaml files where users can make use of a wildcard to specify multiple tables. This PR adds that documentation to he README file
